### PR TITLE
Fixing default appsWhiteList

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ import { Popup } from 'react-native-map-link';
     modalProps={{ // you can put all react-native-modal props inside.
         animationIn: 'slideInUp'
     }}
-    appsWhiteList={{ /* Array of apps (apple-maps, google-maps, etc...) that you want
-    to show in the popup, if is undefined or an empty array it will show all supported apps installed on device.*/}}
+    appsWhiteList={[ /* Array of apps (apple-maps, google-maps, etc...) that you want
+    to show in the popup, if is undefined or an empty array it will show all supported apps installed on device.*/ ]}
     options={{ /* See `showLocation` method above, this accepts the same options. */ }}
     style={{ /* Optional: you can override default style by passing your values. */ }}
 />


### PR DESCRIPTION
The Promise triggered by the modal was silently failing because appsWhiteList was an object. Updating to array, so the copy-and-paste example works without errors.