### PR TITLE
 Fix in navigation with waze app

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -115,7 +115,7 @@ export async function showLocation (options) {
       }
       break
     case 'waze':
-      url = `${prefixes['waze']}?ll=${latlng}&navigate=yes`
+      url = `${prefixes['waze']}?ll=${sourceLatLng}&navigate=yes`
       break
     case 'yandex':
       url = `${prefixes['yandex']}build_route_on_map?lat_to=${lat}&lon_to=${lng}`


### PR DESCRIPTION
the url of the waze application contained an error. in property 'll' the latitude and longitude of the starting point was being used, when in fact it should use the target latitude and longitude. So when the app opened it would direct you to where you already are. When you changed the property to the destination point everything worked as expected.