### PR TITLE
Add option to always include Google Maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ showLocation({
     title: 'The White House',  // optional
     googleForceLatLon: false,  // optionally force GoogleMaps to use the latlon for the query instead of the title
     googlePlaceId: 'ChIJGVtI4by3t4kRr51d_Qm_x58',  // optionally specify the google-place-id
+    alwaysIncludeGoogle: true, // optional, true will always add Google Maps to iOS and open in Safari, even if app is not installed (default: false)
     dialogTitle: 'This is the dialog Title', // optional (default: 'Open in Maps')
     dialogMessage: 'This is the amazing dialog Message', // optional (default: 'What app would you like to use?')
     cancelText: 'This is the cancel button text', // optional (default: 'Cancel')

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,7 @@ interface Options {
     longitude: number | string
     sourceLatitude?: number
     sourceLongitude?: number
+    alwaysIncludeGoogle?: boolean
     googleForceLatLon?: boolean
     googlePlaceId?: string
     title?: string

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,17 +6,25 @@ import { Platform } from 'react-native'
 
 export const isIOS = Platform.OS === 'ios'
 
-export const prefixes = {
-  'apple-maps': isIOS ? 'http://maps.apple.com/' : 'applemaps://',
-  'google-maps': isIOS ? 'comgooglemaps://' : 'https://maps.google.com/',
-  'citymapper': 'citymapper://',
-  'uber': 'uber://',
-  'lyft': 'lyft://',
-  'transit': 'transit://',
-  'waze': 'waze://',
-  'yandex': 'yandexnavi://',
-  'moovit': 'moovit://',
-  'yandex-maps': 'yandexmaps://maps.yandex.ru/'
+export function generatePrefixes(options) {
+  return {
+    'apple-maps': isIOS ? 'http://maps.apple.com/' : 'applemaps://',
+    'google-maps': prefixForGoogleMaps(options.alwaysIncludeGoogle),
+    citymapper: 'citymapper://',
+    uber: 'uber://',
+    lyft: 'lyft://',
+    transit: 'transit://',
+    waze: 'waze://',
+    yandex: 'yandexnavi://',
+    moovit: 'moovit://',
+    'yandex-maps': 'yandexmaps://maps.yandex.ru/',
+  }
+}
+
+export function prefixForGoogleMaps(alwaysIncludeGoogle) {
+  return isIOS && !alwaysIncludeGoogle
+    ? 'comgooglemaps://'
+    : 'https://maps.google.com/'
 }
 
 export const titles = {

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@
 
 import { Linking } from 'react-native'
 
-import { prefixes, isIOS } from './constants'
+import { isIOS, generatePrefixes } from './constants'
 import { askAppChoice, checkOptions } from './utils'
 
 /**
@@ -15,6 +15,7 @@ import { askAppChoice, checkOptions } from './utils'
  *     longitude: number | string,
  *     sourceLatitude: number | undefined | null,
  *     sourceLongitude: number | undefined | null,
+ *     alwaysIncludeGoogle: boolean | undefined | null,
  *     googleForceLatLon: boolean | undefined | null,
  *     googlePlaceId: number | undefined | null,
  *     title: string | undefined | null,
@@ -25,8 +26,9 @@ import { askAppChoice, checkOptions } from './utils'
  *     appsWhiteList: array | undefined | null
  * }} options
  */
-export async function showLocation (options) {
-  checkOptions(options)
+export async function showLocation(options) {
+  const prefixes = generatePrefixes(options)
+  checkOptions(options, prefixes)
 
   let useSourceDestiny = false
   let sourceLat

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,18 +4,18 @@
 
 import { Linking, ActionSheetIOS, Alert } from 'react-native'
 
-import { prefixes, titles, isIOS } from './constants'
+import { titles, isIOS } from './constants'
 
 /**
  * Get available navigation apps.
  */
-export const getAvailableApps = async () => {
+export const getAvailableApps = async (prefixes) => {
   let availableApps = []
   for (let app in prefixes) {
     if (!prefixes.hasOwnProperty(app)) {
       continue
     }
-    let avail = await isAppInstalled(app)
+    let avail = await isAppInstalled(app, prefixes)
     if (avail) {
       availableApps.push(app)
     }
@@ -30,7 +30,7 @@ export const getAvailableApps = async () => {
  * @param {string} app
  * @returns {Promise<boolean>}
  */
-function isAppInstalled (app) {
+function isAppInstalled(app, prefixes) {
   return new Promise((resolve) => {
     if (!(app in prefixes)) {
       return resolve(false)
@@ -50,7 +50,7 @@ function isAppInstalled (app) {
  * @param {string} app
  * @returns {boolean}
  */
-function isSupportedApp (app) {
+function isSupportedApp(app) {
   return Object.keys(titles).includes(app)
 }
 
@@ -60,7 +60,7 @@ function isSupportedApp (app) {
  * @param {array} apps
  * @returns {array}
  */
-function getNotSupportedApps (apps) {
+function getNotSupportedApps(apps) {
   return apps.filter(app => !isSupportedApp(app))
 }
 
@@ -69,7 +69,7 @@ function getNotSupportedApps (apps) {
  *
  * @param {array} apps
  */
-export function checkNotSupportedApps (apps) {
+export function checkNotSupportedApps(apps) {
   let notSupportedApps = getNotSupportedApps(apps)
   if (notSupportedApps.length) {
     throw new MapsException(
@@ -88,7 +88,7 @@ export function checkNotSupportedApps (apps) {
  * }} options
  * @returns {Promise}
  */
-export function askAppChoice ({ dialogTitle, dialogMessage, cancelText, appsWhiteList }) {
+export function askAppChoice({ dialogTitle, dialogMessage, cancelText, appsWhiteList }) {
   return new Promise(async (resolve) => {
     let availableApps = await getAvailableApps()
 
@@ -143,7 +143,7 @@ export function askAppChoice ({ dialogTitle, dialogMessage, cancelText, appsWhit
  *     cancelText: string | undefined | null
  * }} options
  */
-export function checkOptions (options) {
+export function checkOptions(options, prefixes) {
   if (!options || typeof options !== 'object') {
     throw new MapsException('First parameter of `showLocation` should contain object with options.')
   }
@@ -168,7 +168,7 @@ export function checkOptions (options) {
 }
 
 class MapsException {
-  constructor (message) {
+  constructor(message) {
     this.message = message
     this.name = 'MapsException'
   }


### PR DESCRIPTION
The use of Google Maps is the default for so many users. This change adds an option for users to always be able to select Google Maps as their choice, even if the Google Maps app is not installed on their device.

When this option is enabled, it will use the url with https:// maps.google.com, which will open in the Google Maps app, if installed, otherwise it will open in Safari.

There would be no change for Android users.

I don't know if this is an option that fits well with the intent and purpose of the library, but I thought I would offer up a PR for consideration.