### PR TITLE
Google maps displays title but uses provided lat and lng

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,15 @@ export async function showLocation (options) {
       break
     case 'google-maps':
       url = prefixes['google-maps']
-      url += `?q=${!options.googleForceLatLon && title ? encodedTitle : latlng}`
+
+      if (options.googleForceLatLon && title) {
+        url += `?q=loc:${lat},+${lng}+(${encodedTitle})`;
+      } else if (title) {
+        url += `?q=${encodedTitle}`
+      } else {
+        url += `?q=${latlng}`;
+      }
+
       url += (isIOS) ? '&api=1' : ''
       url += (options.googlePlaceId) ? `&query_place_id=${options.googlePlaceId}` : ''
       url += (useSourceDestiny) ? `&saddr=${sourceLatLng}&daddr=${latlng}` : `&ll=${latlng}`

--- a/src/index.js
+++ b/src/index.js
@@ -75,11 +75,11 @@ export async function showLocation (options) {
       url = prefixes['google-maps']
 
       if (options.googleForceLatLon && title) {
-        url += `?q=loc:${lat},+${lng}+(${encodedTitle})`;
+        url += `?q=loc:${lat},+${lng}+(${encodedTitle})`
       } else if (title) {
         url += `?q=${encodedTitle}`
       } else {
-        url += `?q=${latlng}`;
+        url += `?q=${latlng}`
       }
 
       url += (isIOS) ? '&api=1' : ''


### PR DESCRIPTION
## Actual behaviors when using google maps
- If a **title** is provided and `googleForceLatLon: true`, search will be performed using lat and lng but the result will display the  coordinate of the marker but not the provided title.
Example: 
![IMG_6020](https://user-images.githubusercontent.com/3688337/64294894-ec8b0800-cf3d-11e9-945d-57c3c53674a5.PNG)

## Added behavior

If a **title** is provided and `googleForceLatLon: true`, search will be performed using lat and lng and the result will show the provided title.
Example: 
![IMG_6021](https://user-images.githubusercontent.com/3688337/64294902-ef85f880-cf3d-11e9-8ab6-7f29a3e601c5.PNG)