### PR TITLE
Fixing Cannot read property 'style' of undefined

### DIFF
--- a/src/components/Popup.js
+++ b/src/components/Popup.js
@@ -37,6 +37,8 @@ export default class Popup extends React.Component {
       apps: [],
       loading: true
     }
+
+    this._renderAppItem = this._renderAppItem.bind(this)
   }
 
   async componentDidMount () {


### PR DESCRIPTION
## Issue
Commit #9952f69e76bd60b1dbae88e0e88d35f181c4add1 turned arrow functions into functions. Because of this change, `this` needs to be bind manually.

## Screenshot
<img width="376" alt="Screen Shot 2019-09-06 at 12 45 01 PM" src="https://user-images.githubusercontent.com/3688337/64447814-3abd1a00-d0aa-11e9-8999-c88525245699.png">
